### PR TITLE
Fixed Alertifier exporting and event reference error

### DIFF
--- a/src/app/components/alertifier.js
+++ b/src/app/components/alertifier.js
@@ -11,15 +11,13 @@ export const SALUTATION = 'Hey!';
  *
  * Usage: const myAlertifier = Alertifier(document.querySelector('#myAlertifier'));
  */
-export default Alertifier = (container) => {
+const Alertifier = (container) => {
     // Public constant (exposed in returned object)
     const EVENT = 'click';
 
     // Private constants
     const MESSAGE_BEFORE = 'You clicked';
     const MESSAGE_AFTER = 'To make buttons work again, run app.alertifiers[<index of the button>].destroy() in the console.';
-
-    container.addEventListener(EVENT, handleClick);
 
     // Public method (exposed in returned object)
     // Usage: myAlertifier.destroy();
@@ -34,8 +32,12 @@ export default Alertifier = (container) => {
         e.preventDefault();
     };
 
+    container.addEventListener(EVENT, handleClick);
+
     return {
         EVENT,
         destroy
     };
 };
+
+export default Alertifier;


### PR DESCRIPTION
Fixed the following issues:
* Export of `Alertifier` function. `export default Alertifier` throws Alertifier is `undefined`, since it has not been declared yet
* Changed the order of method declaration. It throws error when referencing a method which has not been declared yet