### PR TITLE
Stylelint now fails after error in Production mode

### DIFF
--- a/gulp/tasks/stylelint.js
+++ b/gulp/tasks/stylelint.js
@@ -1,4 +1,5 @@
 const config = require('../config');
+const isProduction = config.environment.isProduction;
 const gulp = require('gulp');
 const stylelint = require('gulp-stylelint');
 const cached = require('gulp-cached');
@@ -8,7 +9,7 @@ gulp.task('stylelint', () => {
         .src(config.CSS_ALL)
         .pipe(cached('stylelint'))
         .pipe(stylelint({
-            failAfterError: false,
+            failAfterError: isProduction,
             reporters: [{
                 formatter: 'string',
                 console: true


### PR DESCRIPTION
Provided a dynamic `failAfterError` option to stylelint config depending on the environment.