### PR TITLE
Styleguide css reload

### DIFF
--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -1,12 +1,14 @@
 const config = require('../config');
+const DEVELOPMENT = require('../environment').isDevelopment;
 const gulp = require('gulp');
+const gulpif = require('gulp-if');
 const browserSync = require('browser-sync');
 const merge = require('merge-stream');
 
 gulp.task('copySgAssets', () => {
     const css = gulp.src(`${config.CSS_BUILD}/*`)
         .pipe(gulp.dest(`${config.STYLEGUIDE_DEST}/css`))
-        .pipe(browserSync.stream());
+        .pipe(gulpif(DEVELOPMENT, browserSync.stream()));
 
     const js = gulp.src(`${config.JS_BUILD}/*`)
         .pipe(gulp.dest(`${config.STYLEGUIDE_DEST}/js`));

--- a/gulp/tasks/copy.js
+++ b/gulp/tasks/copy.js
@@ -1,10 +1,12 @@
 const config = require('../config');
 const gulp = require('gulp');
+const browserSync = require('browser-sync');
 const merge = require('merge-stream');
 
 gulp.task('copySgAssets', () => {
     const css = gulp.src(`${config.CSS_BUILD}/*`)
-        .pipe(gulp.dest(`${config.STYLEGUIDE_DEST}/css`));
+        .pipe(gulp.dest(`${config.STYLEGUIDE_DEST}/css`))
+        .pipe(browserSync.stream());
 
     const js = gulp.src(`${config.JS_BUILD}/*`)
         .pipe(gulp.dest(`${config.STYLEGUIDE_DEST}/js`));

--- a/gulp/tasks/serve.js
+++ b/gulp/tasks/serve.js
@@ -32,7 +32,7 @@ gulp.task('serve', ['prepare'], () => {
     const watch = (glob, tasks) => gwatch(glob, () => runSequence(...tasks));
 
     if (DEVELOPMENT) {
-        watch(config.CSS_ALL, ['styles', 'styleguide']);
+        watch(config.CSS_ALL, ['styles', 'styleguide', 'copySgAssets']);
         watch(config.JS_ALL, ['eslint:app']);
         watch(config.IMAGES_ALL, ['images', 'tpl']);
         watch(config.SVG_SPRITE_ALL, ['svg', 'tpl']);

--- a/gulp/tasks/styleguide.js
+++ b/gulp/tasks/styleguide.js
@@ -12,10 +12,10 @@ const styleguideOptions = {
     // The css and js paths are URLs, like '/misc/jquery.js'.
     // The following paths are relative to the generated style guide.
     css: [
-        'css/main.min.css'
+        'css/main.css'
     ],
     js: [
-        'css/app.min.js'
+        'css/app.js'
     ]
 };
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,7 +1,7 @@
 @import 'bootstrap/variables';
 @import 'bootstrap/bootstrap';
 @import 'variables';
-@import 'base/utilities';
+@import 'base/*';
 
 body {
     font-family: 'Roboto', $font-family-base;


### PR DESCRIPTION
I added live reload of css for styleguide with calling the not minified versions of css and js, since min versions are not generated in --dev mode, plus import all base styles by default, not just utilities