### PR TITLE
add custom fonts to styleguide

### DIFF
--- a/gulp/tasks/styleguide.js
+++ b/gulp/tasks/styleguide.js
@@ -12,7 +12,8 @@ const styleguideOptions = {
     // The css and js paths are URLs, like '/misc/jquery.js'.
     // The following paths are relative to the generated style guide.
     css: [
-        'css/main.min.css'
+        'css/main.css',
+        'https://fonts.googleapis.com/css?family=Roboto:400,700:latin'
     ],
     js: [
         'css/app.min.js'


### PR DESCRIPTION
for adding custom fonts to styleguide, we can just use the url from e.g. Google as a second css argument, since it's still a link tag, there is no need to do another custom item in KSS