### PR TITLE
force no leading zero in stylelint

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,6 +4,6 @@
         "indentation": 4,
         "selector-pseudo-element-colon-notation": "single",
         "declaration-empty-line-before": "never",
-        "number-leading-zero": null
+        "number-leading-zero": never
     }
 }


### PR DESCRIPTION
I set the rule for no leading zero for stylelint from issue #149
Close #149 