### PR TITLE
soften class-methods-use-this rule to warning, add exceptMethods arg

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     rules: {
         'arrow-body-style': 0,
         'arrow-parens': 0, // Does not work with Flow generic types.
+        'class-methods-use-this': [1, { 'exceptMethods': [] }],
         'comma-dangle': [1, 'never'],
         'fp/no-mutating-assign': 2,
         'import/extensions': 2, // Ensure consistent use of file extension.


### PR DESCRIPTION
Close #115 

- Changed the rule to a warning so it doesn’t block the build.
- Exceptions can be added to `exceptMethods` array in `.eslintrc.js:11`.
- React lifecycle methods are ignored by default apparently (according to my testing).