### PR TITLE
#167 - remove gulp uglify

### DIFF
--- a/gulp/tasks/js.js
+++ b/gulp/tasks/js.js
@@ -11,7 +11,6 @@ const envify = require('envify');
 const source = require('vinyl-source-stream');
 const buffer = require('vinyl-buffer');
 const sourcemaps = require('gulp-sourcemaps');
-const uglify = require('gulp-uglify');
 const gutil = require('gulp-util');
 const browserSync = require('browser-sync');
 const config = require('../config');
@@ -33,7 +32,6 @@ function bundle() {
             .pipe(gulpif(DEVELOPMENT, sourcemaps.write('./')))
             .pipe(gulp.dest(config.JS_BUILD))
             .pipe(gulpif(DEVELOPMENT, browserSync.stream()))
-            .pipe(gulpif(PRODUCTION, uglify()))
             .pipe(gulpif(PRODUCTION, rename({ suffix: '.min' })))
             .pipe(gulpif(PRODUCTION, gulp.dest(config.JS_BUILD)));
     };

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "gulp-svgmin": "^1.2.2",
     "gulp-svgstore": "^5.0.5",
     "gulp-tar": "^1.9.0",
-    "gulp-uglify": "^1.4.2",
     "gulp-util": "^3.0.6",
     "gulp-watch": "^4.3.11",
     "handlebars": "^4.0.6",


### PR DESCRIPTION
remove 'gulp-uglify' from package json and gulp task for JS
for minify JS will use only: 'uglifyify'