### PR TITLE
Use modifier class on SVG element itself, not on USE element

### DIFF
--- a/src/tpl/helpers/svg.nunj
+++ b/src/tpl/helpers/svg.nunj
@@ -3,7 +3,7 @@
 {# Example: {{ svg('icon-1', 'my-class') }} uses "svg/sprites/icons/icon-1.svg" with class "my-class" #}
 {# Example: {{ svg(sprite="my-sprite", "icon-2") }} uses "svg/sprites/my-sprite/icon-2.svg" #}
 {% macro svg(name, className, sprite = "icons") %}
-    <svg class="icon">
-        <use{% if className %} class="{{ className }}"{% endif %} xlink:href="{{ _svgSpritesPath }}/{{ sprite }}.svg#{{ name }}" />
+    <svg class="icon{% if className %} {{ className }}{% endif %}">
+        <use xlink:href="{{ _svgSpritesPath }}/{{ sprite }}.svg#{{ name }}" />
     </svg>
 {% endmacro %}


### PR DESCRIPTION
As @ronaldruzicka mentioned in #101 about SVG nunjucks macro, his concern was the `<use>` element has class used for styling, but it's wrapped by `<svg>` element that needs to by styled also (for example some dimensions etc.)

With this approach only one class is present to handle all the styling - on `<svg>` element.